### PR TITLE
oppdatering av versjoner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM navikt/java:11-appdynamics
 
-COPY build/libs/eessi-pensjon-krav-initialisering-*.jar /app/app.jar
+COPY build/libs/eessi-pensjon-krav-initialisering.jar /app/app.jar
 
 COPY nais/export-vault-secrets.sh /init-scripts/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM navikt/java:11-appdynamics
 
-COPY build/libs/eessi-pensjon-krav-initialisering.jar /app/app.jar
+COPY build/libs/eessi-pensjon-krav-initialisering-0.0.1-SNAPSHOT.jar /app/app.jar
 
 COPY nais/export-vault-secrets.sh /init-scripts/
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
 
     ext {
-        kotlinVersion = '1.6.0'
-        springBootVersion = '2.4.3'
-        logstashLogbackVersion = '6.6'
+        kotlinVersion = '1.6.10'
+        springBootVersion = '2.6.1'
+        logstashLogbackVersion = '7.0.1'
     }
 
     repositories {
@@ -27,11 +27,11 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.ben-manes.versions' version '0.28.0'
-    id 'se.patrikerdes.use-latest-versions' version '0.2.15'
-    id "org.owasp.dependencycheck" version "6.5.0.1"
-    id 'com.adarshr.test-logger' version '2.1.1'
-    id "org.sonarqube" version "2.7.1"
+    id 'com.github.ben-manes.versions' version '0.39.0'
+    id 'se.patrikerdes.use-latest-versions' version '0.2.18'
+    id "org.owasp.dependencycheck" version "6.5.1"
+    id 'com.adarshr.test-logger' version '3.1.0'
+    id "org.sonarqube" version "3.3"
     id 'jacoco'
 }
 
@@ -62,7 +62,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'org.springframework.kafka:spring-kafka'
-    testImplementation("com.ninja-squad:springmockk:3.0.1")
+    testImplementation("com.ninja-squad:springmockk:3.1.0")
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude module: 'junit'
         exclude module: "mockito-core"
@@ -71,23 +71,23 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     //aws and s3
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.11.942'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.129'
     testImplementation("io.findify:s3mock_2.13:0.2.6")
 
     //mock - test
     testImplementation('org.junit.jupiter:junit-jupiter:5.8.2')
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
     testImplementation("org.mock-server:mockserver-client-java:5.11.2")
     testImplementation("org.mock-server:mockserver-netty:5.11.2") {
         exclude module: 'junit'
     }
-    testImplementation "io.mockk:mockk:1.12.0"
+    testImplementation "io.mockk:mockk:1.12.1"
 
 
     // Architecture tests
     testImplementation 'com.tngtech.archunit:archunit:0.11.0'
 
-    implementation("no.nav.eessi.pensjon:ep-security-sts:0.0.17")
+    implementation("no.nav.eessi.pensjon:ep-security-sts:0.0.21")
 
     // Micrometer
     implementation("io.micrometer:micrometer-registry-prometheus")
@@ -98,10 +98,10 @@ dependencies {
     configurations { all*.exclude group: 'commons-logging', module: 'commons-logging' }
     implementation group: 'org.slf4j', name: 'jcl-over-slf4j'
 
-    implementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
 
     //eessi pensjon libs
-    implementation("no.nav.eessi.pensjon:ep-logging:1.0.9")
+    implementation("no.nav.eessi.pensjon:ep-logging:1.0.15")
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaConfig.kt
@@ -43,7 +43,7 @@ class KafkaConfig(
         val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
         factory.consumerFactory = aivenKafkaConsumerFactory()
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL
-        factory.containerProperties.authorizationExceptionRetryInterval =  Duration.ofSeconds(4L)
+        factory.containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(4L))
         return factory
     }
 

--- a/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaCustomErrorHandler.kt
+++ b/src/main/kotlin/no/nav/eessi/pensjon/config/KafkaCustomErrorHandler.kt
@@ -16,14 +16,13 @@ class KafkaCustomErrorHandler : ContainerAwareErrorHandler {
 
     private val stopper = ContainerStoppingErrorHandler()
 
-    override fun handle(
-        thrownException: Exception?,
-        records: MutableList<ConsumerRecord<*, *>>?,
-        consumer: Consumer<*, *>?,
-        container: MessageListenerContainer?
-    ) {
+    override fun handle(thrownException: java.lang.Exception,
+                        records: MutableList<ConsumerRecord<*, *>>?,
+                        consumer: Consumer<*, *>,
+                        container: MessageListenerContainer) {
         val stacktrace = StringWriter()
-        thrownException?.printStackTrace(PrintWriter(stacktrace))
+
+        thrownException.printStackTrace(PrintWriter(stacktrace))
 
         logger.error(
             "En feil oppstod under kafka konsumering av meldinger: \n ${hentMeldinger(records)} \n" +

--- a/src/test/kotlin/no/nav/eessi/pensjon/kravinitialisering/config/IntegrasjonsTestConfig.kt
+++ b/src/test/kotlin/no/nav/eessi/pensjon/kravinitialisering/config/IntegrasjonsTestConfig.kt
@@ -35,7 +35,7 @@ class IntegrasjonsTestConfig(@Autowired val kafkaErrorHandler: KafkaCustomErrorH
         val factory = ConcurrentKafkaListenerContainerFactory<String, String>()
         factory.consumerFactory = aivenKafkaConsumerFactory()
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL
-        factory.containerProperties.authorizationExceptionRetryInterval =  Duration.ofSeconds(4L)
+        factory.containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(4L))
         return factory
     }
 


### PR DESCRIPTION
The following dependencies have later release versions:
 - com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin [2.1.1 -> 3.1.0]
 - com.amazonaws:aws-java-sdk-s3 [1.11.942 -> 1.12.129]
     https://aws.amazon.com/sdkforjava
 - com.fasterxml.jackson.module:jackson-module-kotlin [2.11.4 -> 2.13.1]
     https://github.com/FasterXML/jackson-module-kotlin
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.28.0 -> 0.39.0]
 - com.google.guava:guava [30.1-jre -> 31.0.1-jre]
     https://github.com/google/guava
 - com.ninja-squad:springmockk [3.0.1 -> 3.1.0]
     https://github.com/Ninja-Squad/springmockk
 - com.tngtech.archunit:archunit [0.11.0 -> 0.22.0]
     https://github.com/TNG/ArchUnit
 - io.micrometer:micrometer-registry-prometheus [1.6.4 -> 1.8.1]
     https://github.com/micrometer-metrics/micrometer
 - io.mockk:mockk [1.12.0 -> 1.12.1]
     http://mockk.io
 - net.logstash.logback:logstash-logback-encoder [6.6 -> 7.0.1]
     https://github.com/logfellow/logstash-logback-encoder
 - no.nav.eessi.pensjon:ep-logging [1.0.9 -> 1.0.15]
 - no.nav.eessi.pensjon:ep-security-sts [0.0.17 -> 0.0.21]
 - org.jetbrains.kotlin:kotlin-allopen [1.6.0 -> 1.6.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-gradle-plugin [1.6.0 -> 1.6.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-reflect [1.6.0 -> 1.6.10]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8 [1.6.0 -> 1.6.10]
     https://kotlinlang.org/
 - org.junit.jupiter:junit-jupiter-params [5.7.1 -> 5.8.2]
     https://junit.org/junit5/
 - org.owasp.dependencycheck:org.owasp.dependencycheck.gradle.plugin [6.5.0.1 -> 6.5.1]
 - org.slf4j:jcl-over-slf4j [1.7.30 -> 1.7.32]
     http://www.slf4j.org
 - org.sonarqube:org.sonarqube.gradle.plugin [2.7.1 -> 3.3]
 - org.springframework.boot:spring-boot-actuator [2.4.3 -> 2.6.1]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-gradle-plugin [2.4.3 -> 2.6.1]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-actuator [2.4.3 -> 2.6.1]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-aop [2.4.3 -> 2.6.1]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-test [2.4.3 -> 2.6.1]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-web [2.4.3 -> 2.6.1]
     https://spring.io/projects/spring-boot
 - org.springframework.kafka:spring-kafka [2.6.6 -> 2.8.1]
     https://github.com/spring-projects/spring-kafka
 - org.springframework.kafka:spring-kafka-test [2.6.6 -> 2.8.1]
     https://github.com/spring-projects/spring-kafka
 - se.patrikerdes.use-latest-versions:se.patrikerdes.use-latest-versions.gradle.plugin [0.2.15 -> 0.2.18]

Gradle release-candidate updates:
 - Gradle: [7.3.1 -> 7.3.2]